### PR TITLE
Release 0.8.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ compileGroovy {
     targetCompatibility '1.7'
 }
 
-version = "0.7.2"
+version = "0.8.0"
 group = "com.auth0.gradle"
 
 // The configuration example below shows the minimum required properties

--- a/src/main/groovy/com/auth0/gradle/oss/LibraryPlugin.groovy
+++ b/src/main/groovy/com/auth0/gradle/oss/LibraryPlugin.groovy
@@ -27,7 +27,7 @@ class LibraryPlugin implements Plugin<Project> {
 
     private void java(Project project) {
         project.configure(project) {
-            apply plugin: 'java'
+            apply plugin: 'java-library'
             apply plugin: 'maven-publish'
             task('sourcesJar', type: Jar, dependsOn: classes) {
                 classifier = 'sources'

--- a/src/test/groovy/com/auth0/gradle/oss/LibraryPluginTest.groovy
+++ b/src/test/groovy/com/auth0/gradle/oss/LibraryPluginTest.groovy
@@ -60,7 +60,7 @@ class LibraryPluginTest extends Specification {
 
         where:
         name | _
-        "java" | _
+        "java-library" | _
         "maven-publish" | _
     }
 


### PR DESCRIPTION
Fix the `com.auth0.gradle.oss-library.java` plugin: 

Use `java-library` instead of the `java` plugin. This allows one to use `implementation` and `api` vs only `implementation` when requiring dependencies.  

Known issues for this change are [here](https://docs.gradle.org/current/userguide/java_library_plugin.html). Including incompatibility with Kotlin and Groovy plugins.