### PR TITLE
Include project attributes in the jar's manifest file

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Oct 23 16:44:55 ART 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,3 +17,4 @@ include 'services:webservice'
 */
 
 rootProject.name = 'oss-library'
+enableFeaturePreview('STABLE_PUBLISHING')

--- a/src/main/groovy/com/auth0/gradle/oss/LibraryPlugin.groovy
+++ b/src/main/groovy/com/auth0/gradle/oss/LibraryPlugin.groovy
@@ -55,6 +55,11 @@ class LibraryPlugin implements Plugin<Project> {
                 }
             }
         }
+        project.tasks.withType(Jar) {
+            manifest {
+                attributes 'Implementation-Title': project.name, 'Implementation-Version': project.version
+            }
+        }
     }
 
     private void maven(Project project, String packaging = 'jar') {


### PR DESCRIPTION
This PR changes the java library plugin in order to include in the jar's manifest file the following properties:
- `Implementation-Title`
- `Implementation-Version`

This is analogous to android's generated `BuildConfig.java` file, and would help java projects using this plugin to obtain at runtime the project's version and name. The code to obtain this values is:

```java
String version = SomeClass.class.getPackage().getImplementationVersion();
String title = SomeClass.class.getPackage().getImplementationTitle();
```

Note however that both methods will return `null` when they are run from anywhere else but the release/assembled jar file.