### PR TITLE
handle javaCompile on new gradle versions

### DIFF
--- a/src/main/groovy/com/auth0/gradle/oss/AndroidLibraryPlugin.groovy
+++ b/src/main/groovy/com/auth0/gradle/oss/AndroidLibraryPlugin.groovy
@@ -27,7 +27,12 @@ class AndroidLibraryPlugin implements Plugin<Project> {
         bintray(project)
         jacoco(project)
         project.afterEvaluate {
-            project.javadoc.classpath += project.android.libraryVariants.toList().first().javaCompile.classpath
+            def variant = project.android.libraryVariants.toList().first()
+            if (variant.hasProperty('javaCompileProvider')) {
+                project.javadoc.classpath += variant.javaCompileProvider.get().classpath
+            } else {
+                project.javadoc.classpath += variant.javaCompile.classpath
+            }
             project.publishToMavenLocal.dependsOn project.assemble
             def bintrayUpload = project.tasks.findByName("bintrayUpload")
             if (bintrayUpload) {
@@ -64,7 +69,11 @@ class AndroidLibraryPlugin implements Plugin<Project> {
                 classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
                 android.libraryVariants.all { variant ->
                     if (variant.name == 'release') {
-                        owner.classpath += variant.javaCompile.classpath
+                        if (variant.hasProperty('javaCompileProvider')) {
+                            owner.classpath += variant.javaCompileProvider.get().classpath
+                        } else {
+                            owner.classpath += variant.javaCompile.classpath
+                        }
                     }
                 }
                 exclude '**/BuildConfig.java'


### PR DESCRIPTION
### Description

`javaCompile` was deprecated a while ago, and will be removed on the next Gradle version. Since this is a gradle plugin for libraries that could be used with many gradle versions, I added support for handling the legacy behavior as well as the new one.

### References
Attempt to fix #10

### Testing
No tests :D 

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
