### PR TITLE
Add API Compatibility Task to Java Libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ plugins {
 repositories {
     google()
     jcenter()
+    gradlePluginPortal()
 }
 
 tasks.wrapper {
@@ -15,6 +16,9 @@ tasks.wrapper {
 }
 
 dependencies {
+    implementation "me.champeau.gradle:japicmp-gradle-plugin:0.2.9"
+    // needed because of https://github.com/melix/japicmp-gradle-plugin/issues/36
+    implementation 'com.google.guava:guava:28.2-jre'
     testImplementation("org.spockframework:spock-core:1.0-groovy-2.4") {
         exclude module: 'groovy-all'
     }
@@ -42,7 +46,7 @@ tasks.withType(Test).configureEach {
     }
 }
 
-version = "0.13.0"
+version = "0.14.0"
 group = "com.auth0.gradle"
 
 gradlePlugin {

--- a/src/main/groovy/com/auth0/gradle/oss/LibraryPlugin.groovy
+++ b/src/main/groovy/com/auth0/gradle/oss/LibraryPlugin.groovy
@@ -224,7 +224,7 @@ class LibraryPlugin implements Plugin<Project> {
                 apply plugin: 'me.champeau.gradle.japicmp'
                 task('apiDiff', type: JapicmpTask, dependsOn: 'jar') {
                     oldClasspath = files(getBaselineJar(project, baselineVersion))
-                    newClasspath = files("$buildDir/libs/${project.name}-${project.version}.jar")
+                    newClasspath = files(jar.archiveFile)
                     onlyModified = true
                     failOnModification = true
                     ignoreMissingClasses = true

--- a/src/main/groovy/com/auth0/gradle/oss/LibraryPlugin.groovy
+++ b/src/main/groovy/com/auth0/gradle/oss/LibraryPlugin.groovy
@@ -217,20 +217,21 @@ class LibraryPlugin implements Plugin<Project> {
         project.afterEvaluate {
             def lib = project.extensions.oss
             def baselineVersion = lib.baselineVersion
-            if (baselineVersion) {
-                project.configure(project) {
-                    apply plugin: 'me.champeau.gradle.japicmp'
-                    task('apiDiff', type: JapicmpTask, dependsOn: 'jar') {
-                        oldClasspath = files(getBaselineJar(project, baselineVersion))
-                        newClasspath = files("$buildDir/libs/${project.name}-${project.version}.jar")
-                        onlyModified = true
-                        failOnModification = true
-                        ignoreMissingClasses = true
-                        htmlOutputFile = file("$buildDir/reports/apiDiff/apiDiff.html")
-                        txtOutputFile = file("$buildDir/reports/apiDiff/apiDiff.txt")
-                        doLast {
-                            project.logger.quiet("Comparing against baseline version ${baselineVersion}")
-                        }
+            if (!baselineVersion) {
+                return
+            }
+            project.configure(project) {
+                apply plugin: 'me.champeau.gradle.japicmp'
+                task('apiDiff', type: JapicmpTask, dependsOn: 'jar') {
+                    oldClasspath = files(getBaselineJar(project, baselineVersion))
+                    newClasspath = files("$buildDir/libs/${project.name}-${project.version}.jar")
+                    onlyModified = true
+                    failOnModification = true
+                    ignoreMissingClasses = true
+                    htmlOutputFile = file("$buildDir/reports/apiDiff/apiDiff.html")
+                    txtOutputFile = file("$buildDir/reports/apiDiff/apiDiff.txt")
+                    doLast {
+                        project.logger.quiet("Comparing against baseline version ${baselineVersion}")
                     }
                 }
             }

--- a/src/main/groovy/com/auth0/gradle/oss/LibraryPlugin.groovy
+++ b/src/main/groovy/com/auth0/gradle/oss/LibraryPlugin.groovy
@@ -216,7 +216,7 @@ class LibraryPlugin implements Plugin<Project> {
     private void japiCmp(Project project) {
         project.afterEvaluate {
             def lib = project.extensions.oss
-            def baselineVersion = lib.baselineVersion
+            def baselineVersion = lib.baselineCompareVersion
             if (!baselineVersion) {
                 return
             }

--- a/src/main/groovy/com/auth0/gradle/oss/extensions/Library.groovy
+++ b/src/main/groovy/com/auth0/gradle/oss/extensions/Library.groovy
@@ -5,4 +5,5 @@ class Library {
     String organization
     String repository
     String description
+    String baselineVersion
 }

--- a/src/main/groovy/com/auth0/gradle/oss/extensions/Library.groovy
+++ b/src/main/groovy/com/auth0/gradle/oss/extensions/Library.groovy
@@ -5,5 +5,5 @@ class Library {
     String organization
     String repository
     String description
-    String baselineVersion
+    String baselineCompareVersion
 }


### PR DESCRIPTION
### Description

Currently, we rely on manual inspection of changes to ensure no breaking changes are introduced. Instead, we can leverage an API compatibility-checker, [JApiCmp](https://github.com/siom79/japicmp) through the [JApicmp Gradle Plugin](https://github.com/melix/japicmp-gradle-plugin).

This change adds a task, `apiDiff`, to Java projects that specify a `baselineCompareVersion ` property in the `oss` config:

```groovy
oss {
    // ...
    baselineCompareVersion "3.13.0"
}
``` 

**Details**:
- The task will not be added if the `baselineCompareVersion` configuration property is not added
- The task will not be added to Android projects with this change. As we utilize it for Java projects first, we can extract the task to handle Android as well if it proves useful.

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
