### PR TITLE
Use newer Javadoc template for Java libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,38 @@ This will place the jar in the `build/libs/` folder
 │   │   └── oss-library-x.y.z.jar
 ```
 
-Open the project you want to use this plugin on. From the project-wide `build.gradle` file, edit the builscript dependencies to reference the jar file:
+### Using the PluginManagement syntax (easiest)
+
+In the project `settings.gradle` file or where you declare the `pluginManagement` block, add the plugin project directly using the `includeBuild` method.
+
+```gradle
+// settings.gradle
+pluginManagement {
+    includeBuild '/path/to/oss-library-gradle-plugin'
+    repositories {
+        gradlePluginPortal()
+    }
+    plugins {
+        // No need to add the plugin here
+    }
+}
+```
+
+Then in the app's `build.gradle` file, apply the plugin:
+
+```gradle
+plugin {
+    id 'java'
+    id 'com.auth0.gradle.oss-library.java'
+}
+```
+
+Sync the gradle project to refresh the changes in the plugin code. No need to package or publish the jar. If everything went right, your project is now using the most recent local version of the plugin. 
+
+
+### Without the PluginManagement syntax
+
+Open the project you want to use this plugin on. From the project-wide `build.gradle` file, edit the builscript block dependencies to reference the local jar file:
 
 ```groovy
 buildscript {
@@ -165,7 +196,7 @@ buildscript {
 }
 ```
 
-Now in order to apply it, go to the app's `build.gradle` file and add the fully qualified package + class name. Note there are no quotes around it. In the case of an Android app, it will look like this:
+Then in the app's `build.gradle` file, apply the plugin using the fully qualified package + class name. In the case of an Android app, it will look like this:
 
 ```groovy
 // old plugin syntax
@@ -173,14 +204,20 @@ apply plugin: 'com.auth0.gradle.oss.AndroidLibraryPlugin'
 
 // new plugin syntax
 plugins {
-    id "com.auth0.gradle.oss-library.android"
+    id 'com.auth0.gradle.oss-library.android'
 }
 ```
 
-For java libraries, the Plugin name will be different:
+For java libraries, the Plugin name changes:
 
 ```groovy
+// old plugin syntax
 apply plugin: 'com.auth0.gradle.oss.LibraryPlugin'
+
+// new plugin syntax
+plugins {
+    id 'com.auth0.gradle.oss-library.java'
+}
 ```
 
 Go ahead and sync the project with the gradle files. If everything went right, your project is now using the most recent local version of the plugin. 

--- a/src/main/groovy/com/auth0/gradle/oss/LibraryPlugin.groovy
+++ b/src/main/groovy/com/auth0/gradle/oss/LibraryPlugin.groovy
@@ -15,6 +15,8 @@ import org.gradle.api.artifacts.ExcludeRule
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
 import org.gradle.api.tasks.bundling.Jar
+import org.gradle.api.tasks.javadoc.Javadoc
+import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.plugins.signing.Sign
 
 class LibraryPlugin implements Plugin<Project> {
@@ -42,7 +44,16 @@ class LibraryPlugin implements Plugin<Project> {
                 classifier = 'javadoc'
                 from javadoc.getDestinationDir()
             }
-
+            tasks.withType(Javadoc).configureEach {
+                javadocTool = javaToolchains.javadocToolFor {
+                    // Use latest JDK for javadoc generation
+                    languageVersion = JavaLanguageVersion.of(16)
+                }
+            }
+            javadoc {
+                // Specify the Java version that the project will use
+                options.addStringOption('-release', "8")
+            }
             artifacts {
                 archives sourcesJar, javadocJar
             }


### PR DESCRIPTION
This PR makes the Javadoc task target a newer JDK version that includes an improved Javadoc template. This change impacts only the Java library plugin.

I also updated the README with notes about developing and testing the plugin locally, following what's described in the official docs here https://docs.gradle.org/current/userguide/testing_gradle_plugins.html#manual-tests.

#### Before
![image](https://user-images.githubusercontent.com/3900123/123671152-40b35a80-d83e-11eb-8048-1c9b8d10ed47.png)

#### After
![image](https://user-images.githubusercontent.com/3900123/123671172-4610a500-d83e-11eb-9e4d-7782a681b782.png)
