### PR TITLE
Release 0.16.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ tasks.withType(Test).configureEach {
     }
 }
 
-version = "0.15.1"
+version = "0.16.0"
 group = "com.auth0.gradle"
 
 gradlePlugin {


### PR DESCRIPTION
This release changes the Java library plugin to use a newer Javadoc template from JDK 16.