### PR TITLE
Support manual versioning by avoiding relying on git tags

### DIFF
--- a/src/main/groovy/com/auth0/gradle/oss/AndroidLibraryPlugin.groovy
+++ b/src/main/groovy/com/auth0/gradle/oss/AndroidLibraryPlugin.groovy
@@ -25,6 +25,7 @@ class AndroidLibraryPlugin implements Plugin<Project> {
         project.rootProject.pluginManager.apply(RootProjectPlugin)
         project.extensions.create('oss', Library)
         project.oss.extensions.developers = project.container(Developer)
+        project.ext.isSnapshot = project.hasProperty('isSnapshot') ? project.isSnapshot.toBoolean() : true
         release(project)
         java(project)
         maven(project)
@@ -228,7 +229,8 @@ class AndroidLibraryPlugin implements Plugin<Project> {
     }
 
     private void release(Project project) {
-        def semver = Semver.current()
+        def hasVersion = project.version != null && project.version != "unspecified"
+        def semver = hasVersion ? new Semver(project.version, project.ext.isSnapshot) : Semver.current()
         project.version = semver.version
         project.ext.isReleaseVersion = !semver.snapshot
         def version = semver.nonSnapshot

--- a/src/main/groovy/com/auth0/gradle/oss/LibraryPlugin.groovy
+++ b/src/main/groovy/com/auth0/gradle/oss/LibraryPlugin.groovy
@@ -25,6 +25,7 @@ class LibraryPlugin implements Plugin<Project> {
         project.rootProject.pluginManager.apply(RootProjectPlugin)
         project.extensions.create('oss', Library)
         project.oss.extensions.developers = project.container(Developer)
+        project.ext.isSnapshot = project.hasProperty('isSnapshot') ? project.isSnapshot.toBoolean() : true
         release(project)
         java(project)
         maven(project)
@@ -187,7 +188,8 @@ class LibraryPlugin implements Plugin<Project> {
     }
 
     private void release(Project project) {
-        def semver = Semver.current()
+        def hasVersion = project.version != null && project.version != "unspecified"
+        def semver = hasVersion ? new Semver(project.version, project.ext.isSnapshot) : Semver.current()
         project.version = semver.version
         def version = semver.nonSnapshot
         project.ext.isReleaseVersion = !semver.snapshot


### PR DESCRIPTION
### Description

Currently, this plugin is setup in a way where it always calculates the version based on the current Git tag. If you haven't checked out that tag, it will produce a `SNAPSHOT` set of jars.

With our new way of releasing SDKs using Ship CLI and Circle CI's Ship Orb, we need to modify the process a bit.

Projects should contain their own version property, which will be bumped by the Ship CLI, which then will be published by the Ship Orb. 

To support that, we need to avoid using `Semver.current()` in the above use-case, which typically is when an explicit version is defined. Instead, we use the `Semver` constructor which takes the `version` and a `boolean` indicating whether or not it's a snapshot.

We will default to using a snapshot, avoiding the need to provide any arguments when building a SNAPSHOT. If you dont want to build a snapshot, the `isSnapshot` value needs to be set to `false`, which we will do in the Orb by passing `-PisSnapshot` to the Gradle CLI.

We are using a global project property because it seems that Library properties (defined on the plugin's Library class) are not initialized when running the plugins `apply` method.


### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
