### PR TITLE
Release 0.17.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ tasks.withType(Test).configureEach {
     }
 }
 
-version = "0.16.0"
+version = "0.17.0"
 group = "com.auth0.gradle"
 
 gradlePlugin {


### PR DESCRIPTION
This release adds the ability to opt out of using git-tags for Semver, but instead manually take control over the version.