### PR TITLE
Allow to skip AssertSigningConfiguration

### DIFF
--- a/src/main/groovy/com/auth0/gradle/oss/AndroidLibraryPlugin.groovy
+++ b/src/main/groovy/com/auth0/gradle/oss/AndroidLibraryPlugin.groovy
@@ -215,7 +215,9 @@ class AndroidLibraryPlugin implements Plugin<Project> {
         def sonatypeConfiguration = new SonatypeConfiguration(project)
         project.tasks.withType(Sign) {
             doFirst {
-                sonatypeConfiguration.assertSigningConfiguration()
+                if (!lib.skipAssertSigningConfiguration) {
+                    sonatypeConfiguration.assertSigningConfiguration()
+                }
             }
         }
         project.tasks.withType(PublishToMavenRepository) {

--- a/src/main/groovy/com/auth0/gradle/oss/LibraryPlugin.groovy
+++ b/src/main/groovy/com/auth0/gradle/oss/LibraryPlugin.groovy
@@ -174,7 +174,9 @@ class LibraryPlugin implements Plugin<Project> {
         def sonatypeConfiguration = new SonatypeConfiguration(project)
         project.tasks.withType(Sign) {
             doFirst {
-                sonatypeConfiguration.assertSigningConfiguration()
+                if (!lib.skipAssertSigningConfiguration) {
+                    sonatypeConfiguration.assertSigningConfiguration()
+                }
             }
         }
         project.tasks.withType(PublishToMavenRepository) {

--- a/src/main/groovy/com/auth0/gradle/oss/extensions/Library.groovy
+++ b/src/main/groovy/com/auth0/gradle/oss/extensions/Library.groovy
@@ -6,4 +6,5 @@ class Library {
     String repository
     String description
     String baselineCompareVersion
+    Boolean skipAssertSigningConfiguration
 }


### PR DESCRIPTION
### Description

This plugin does not allow to sign the artifacts unless the corresponding project properties are defined. However, when publishing from Circle CI, we do not use these properties. To be able to still sign the artifacts, we will need to be able to skip the assertion by introducing a flag `skipAssertSigningConfiguration`.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
