### PR TITLE
Use java 17 toolchain for javadoc tasks

### DIFF
--- a/src/main/groovy/com/auth0/gradle/oss/LibraryPlugin.groovy
+++ b/src/main/groovy/com/auth0/gradle/oss/LibraryPlugin.groovy
@@ -48,7 +48,7 @@ class LibraryPlugin implements Plugin<Project> {
             tasks.withType(Javadoc).configureEach {
                 javadocTool = javaToolchains.javadocToolFor {
                     // Use latest JDK for javadoc generation
-                    languageVersion = JavaLanguageVersion.of(16)
+                    languageVersion = JavaLanguageVersion.of(17)
                 }
             }
             javadoc {


### PR DESCRIPTION
Bump Javadoc tasks to use Java 17 instead of 16. Aside from the benefits of using an LTS version, 16 is not widely available via SDK managers such as SDKMAN, which can cause build issues.